### PR TITLE
fix(infra): Separate the postgres repository from the couchbase

### DIFF
--- a/infra/postgres/repository.go
+++ b/infra/postgres/repository.go
@@ -1,4 +1,4 @@
-package couchbase
+package postgres
 
 import (
 	"context"
@@ -15,9 +15,11 @@ func NewPgRepository() *PgRepository {
 }
 
 func (r *PgRepository) GetProduct(ctx context.Context, id string) (*domain.Product, error) {
+	// TODO: implement
 	return nil, nil
 }
 
 func (r *PgRepository) CreateProduct(ctx context.Context, product *domain.Product) error {
+	// TODO: implement
 	return nil
 }


### PR DESCRIPTION
Separated the postgres repository from the coucbase module. 

Current structure looks like this.
```lua
├── infra
│ └── couchbase
│── └── repository.go
│ └── postgres
│── └── repository.go
```